### PR TITLE
Eliminate unixisms and add testing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 target
 Cargo.lock
 .cargo
-output
-index
+*~
+work


### PR DESCRIPTION
Restructures the output to so all the file manipulation is in the
'work' directory, which in turn contains 'index', '.cargo', 'stdio',
'results', and 'cargo-home'.
